### PR TITLE
Add CMake configuration of LibComm

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,68 @@
+name: Test with CMake
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libcereal-dev \
+            libopenmpi-dev \
+            ninja-build \
+            openmpi-bin
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
+            -DBUILD_TESTING=ON
+
+      - name: Check public headers
+        run: cmake --build build --target libcomm_public_header_check -j $(nproc)
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Install
+        run: cmake --install build
+
+      - name: Test installed package
+        run: |
+          mkdir -p consumer
+          cat > consumer/CMakeLists.txt <<'EOF'
+          cmake_minimum_required(VERSION 3.23)
+          project(LibCommConsumer LANGUAGES CXX)
+
+          find_package(LibComm CONFIG REQUIRED)
+
+          add_executable(libcomm_consumer main.cpp)
+          target_link_libraries(libcomm_consumer PRIVATE LibComm::LibComm)
+          EOF
+
+          cat > consumer/main.cpp <<'EOF'
+          #include <Comm/Comm_Assemble/Comm_Assemble.h>
+
+          int main()
+          {
+              return 0;
+          }
+          EOF
+
+          cmake -S consumer -B consumer/build -G Ninja \
+            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install"
+          cmake --build consumer/build --parallel 2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,15 +25,13 @@ jobs:
             ninja-build \
             openmpi-bin
 
-      - name: Configure
+      - name: Configure & Build
         run: |
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install" \
             -DBUILD_TESTING=ON
-
-      - name: Check public headers
-        run: cmake --build build --target libcomm_public_header_check -j $(nproc)
+          cmake --build build -j $(nproc)
 
       - name: Run tests
         run: ctest --test-dir build --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 .envrc
 .clangd
+/build/
+/install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,123 @@
+cmake_minimum_required(VERSION 3.23)
+
+set(LIBCOMM_PACKAGE_VERSION "0.2.0" CACHE STRING
+  "Package version used for generated LibCommConfigVersion.cmake when the source tree has no explicit release version.")
+
+project(LibComm
+  VERSION "${LIBCOMM_PACKAGE_VERSION}"
+  DESCRIPTION "Header-only MPI communication helpers used by LibRI and ABACUS"
+  LANGUAGES CXX)
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+include(CTest)
+
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+option(LIBCOMM_INSTALL_EXAMPLE_HEADERS
+  "Install example helper headers under include/Comm/example."
+  ON)
+option(LIBCOMM_ENABLE_HEADER_CHECK
+  "Add an explicit, non-default target that checks public headers for self-contained compilation."
+  ON)
+
+find_package(Threads REQUIRED)
+find_package(MPI REQUIRED COMPONENTS CXX)
+find_package(OpenMP REQUIRED COMPONENTS CXX)
+find_package(cereal REQUIRED)
+
+file(GLOB_RECURSE LIBCOMM_PUBLIC_HEADERS CONFIGURE_DEPENDS
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/Comm/*.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/Comm/*.hpp")
+
+if(NOT LIBCOMM_INSTALL_EXAMPLE_HEADERS)
+  list(FILTER LIBCOMM_PUBLIC_HEADERS EXCLUDE REGEX "/include/Comm/example/")
+endif()
+
+add_library(LibComm INTERFACE)
+add_library(LibComm::LibComm ALIAS LibComm)
+
+set_target_properties(LibComm PROPERTIES
+  EXPORT_NAME LibComm)
+
+target_sources(LibComm
+  INTERFACE
+    FILE_SET public_headers
+    TYPE HEADERS
+    BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    FILES ${LIBCOMM_PUBLIC_HEADERS})
+
+target_compile_features(LibComm INTERFACE cxx_std_17)
+
+target_include_directories(LibComm
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+
+target_link_libraries(LibComm
+  INTERFACE
+    MPI::MPI_CXX
+    OpenMP::OpenMP_CXX
+    Threads::Threads
+    cereal::cereal)
+
+install(TARGETS LibComm
+  EXPORT LibCommTargets
+  FILE_SET public_headers DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+install(EXPORT LibCommTargets
+  NAMESPACE LibComm::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/LibComm")
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibCommConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/LibCommConfig.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/LibComm")
+
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/LibCommConfigVersion.cmake"
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/LibCommConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/LibCommConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/LibComm")
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
+  DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+
+if(BUILD_TESTING AND LIBCOMM_ENABLE_HEADER_CHECK)
+  add_custom_target(libcomm_public_header_check)
+  set(_libcomm_header_check_index 0)
+  foreach(_libcomm_header IN LISTS LIBCOMM_PUBLIC_HEADERS)
+    math(EXPR _libcomm_header_check_index "${_libcomm_header_check_index} + 1")
+    file(RELATIVE_PATH _libcomm_header_rel
+      "${CMAKE_CURRENT_SOURCE_DIR}/include"
+      "${_libcomm_header}")
+    set(_libcomm_header_check_source
+      "${CMAKE_CURRENT_BINARY_DIR}/header_check_${_libcomm_header_check_index}.cpp")
+    file(WRITE "${_libcomm_header_check_source}"
+      "#include <${_libcomm_header_rel}>\nint main() { return 0; }\n")
+    add_executable(libcomm_header_check_${_libcomm_header_check_index}
+      EXCLUDE_FROM_ALL
+      "${_libcomm_header_check_source}")
+    target_link_libraries(libcomm_header_check_${_libcomm_header_check_index}
+      PRIVATE LibComm::LibComm)
+    add_dependencies(libcomm_public_header_check
+      libcomm_header_check_${_libcomm_header_check_index})
+  endforeach()
+
+  add_test(NAME libcomm_public_header_check
+    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}"
+            --target libcomm_public_header_check
+            --config "$<CONFIG>")
+endif()
+
+set(CPACK_PACKAGE_NAME "LibComm")
+set(CPACK_PACKAGE_VENDOR "ABACUS")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Header-only MPI communication helpers")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_GENERATOR "TGZ")
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
+if(POLICY CMP0144) # https://cmake.org/cmake/help/git-stage/policy/CMP0144.html
+  cmake_policy(SET CMP0144 NEW)
+endif()
 
 set(LIBCOMM_PACKAGE_VERSION "0.2.0" CACHE STRING
   "Package version used for generated LibCommConfigVersion.cmake when the source tree has no explicit release version.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ if(NOT LIBCOMM_INSTALL_EXAMPLE_HEADERS)
 endif()
 
 add_library(LibComm INTERFACE)
-add_library(LibComm::LibComm ALIAS LibComm)
 
 set_target_properties(LibComm PROPERTIES
   EXPORT_NAME LibComm)
@@ -84,6 +83,7 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
   DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 
 if(BUILD_TESTING)
+  add_library(LibComm::LibComm ALIAS LibComm)
   set(_libcomm_header_check_index 0)
   foreach(_libcomm_header IN LISTS LIBCOMM_PUBLIC_HEADERS)
     math(EXPR _libcomm_header_check_index "${_libcomm_header_check_index} + 1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,8 @@ include(CTest)
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-option(LIBCOMM_INSTALL_EXAMPLE_HEADERS
-  "Install example helper headers under include/Comm/example."
-  ON)
-option(LIBCOMM_ENABLE_HEADER_CHECK
-  "Add an explicit, non-default target that checks public headers for self-contained compilation."
-  ON)
+option(LIBCOMM_INSTALL_EXAMPLE_HEADERS "Install example helper headers under include/Comm/example." ON)
+option(BUILD_TESTING "Enable unittest: check public headers for self-contained compilation." OFF)
 
 find_package(Threads REQUIRED)
 find_package(MPI REQUIRED COMPONENTS CXX)
@@ -87,31 +83,28 @@ install(FILES
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
   DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 
-if(BUILD_TESTING AND LIBCOMM_ENABLE_HEADER_CHECK)
-  add_custom_target(libcomm_public_header_check)
+if(BUILD_TESTING)
   set(_libcomm_header_check_index 0)
   foreach(_libcomm_header IN LISTS LIBCOMM_PUBLIC_HEADERS)
     math(EXPR _libcomm_header_check_index "${_libcomm_header_check_index} + 1")
     file(RELATIVE_PATH _libcomm_header_rel
       "${CMAKE_CURRENT_SOURCE_DIR}/include"
       "${_libcomm_header}")
+    set(_libcomm_header_check_target
+      "libcomm_public_header_check_${_libcomm_header_check_index}")
     set(_libcomm_header_check_source
-      "${CMAKE_CURRENT_BINARY_DIR}/header_check_${_libcomm_header_check_index}.cpp")
+      "${CMAKE_CURRENT_BINARY_DIR}/${_libcomm_header_check_target}.cpp")
     file(WRITE "${_libcomm_header_check_source}"
-      "#include <${_libcomm_header_rel}>\nint main() { return 0; }\n")
-    add_executable(libcomm_header_check_${_libcomm_header_check_index}
-      EXCLUDE_FROM_ALL
+      "#include <${_libcomm_header_rel}>\n"
+      "int main() { return 0; }\n")
+    add_executable(${_libcomm_header_check_target}
       "${_libcomm_header_check_source}")
-    target_link_libraries(libcomm_header_check_${_libcomm_header_check_index}
+    target_link_libraries(${_libcomm_header_check_target}
       PRIVATE LibComm::LibComm)
-    add_dependencies(libcomm_public_header_check
-      libcomm_header_check_${_libcomm_header_check_index})
+    add_test(
+      NAME "${_libcomm_header_check_target}"
+      COMMAND ${_libcomm_header_check_target})
   endforeach()
-
-  add_test(NAME libcomm_public_header_check
-    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}"
-            --target libcomm_public_header_check
-            --config "$<CONFIG>")
 endif()
 
 set(CPACK_PACKAGE_NAME "LibComm")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,14 @@ install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/LibCommConfigVersion.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/LibComm")
 
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/libcomm.pc.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/libcomm.pc"
+  @ONLY)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libcomm.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
   DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,8 @@ if(POLICY CMP0144) # https://cmake.org/cmake/help/git-stage/policy/CMP0144.html
   cmake_policy(SET CMP0144 NEW)
 endif()
 
-set(LIBCOMM_PACKAGE_VERSION "0.2.0" CACHE STRING
-  "Package version used for generated LibCommConfigVersion.cmake when the source tree has no explicit release version.")
-
 project(LibComm
-  VERSION "${LIBCOMM_PACKAGE_VERSION}"
+  VERSION 0.2.0
   DESCRIPTION "Header-only MPI communication helpers used by LibRI and ABACUS"
   LANGUAGES CXX)
 

--- a/cmake/LibCommConfig.cmake.in
+++ b/cmake/LibCommConfig.cmake.in
@@ -1,0 +1,17 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+find_dependency(Threads)
+find_dependency(MPI COMPONENTS CXX)
+find_dependency(OpenMP COMPONENTS CXX)
+find_package(cereal CONFIG QUIET)
+if(NOT cereal_FOUND)
+  find_dependency(Cereal)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/LibCommTargets.cmake")
+
+check_required_components(LibComm)

--- a/cmake/LibCommConfig.cmake.in
+++ b/cmake/LibCommConfig.cmake.in
@@ -4,13 +4,10 @@ include(CMakeFindDependencyMacro)
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 
-find_dependency(Threads)
-find_dependency(MPI COMPONENTS CXX)
-find_dependency(OpenMP COMPONENTS CXX)
-find_package(cereal CONFIG QUIET)
-if(NOT cereal_FOUND)
-  find_dependency(Cereal)
-endif()
+find_dependency(Threads REQUIRED)
+find_dependency(MPI COMPONENTS CXX REQUIRED)
+find_dependency(OpenMP COMPONENTS CXX REQUIRED)
+find_dependency(cereal CONFIG REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/LibCommTargets.cmake")
 

--- a/cmake/libcomm.pc.in
+++ b/cmake/libcomm.pc.in
@@ -1,0 +1,9 @@
+# LibComm is header-only. Use an MPI C++ compiler wrapper (for example, mpicxx).
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: LibComm
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir} -fopenmp -pthread
+Libs: -fopenmp -pthread

--- a/include/Comm/Comm_Keys/Comm_Keys_32-sr.hpp
+++ b/include/Comm/Comm_Keys/Comm_Keys_32-sr.hpp
@@ -9,6 +9,7 @@
 #include "../global/Cereal_Func.h"
 
 #include <mpi.h>
+#include <cassert>
 #include <thread>
 
 #define MPI_CHECK(x) if((x)!=MPI_SUCCESS)	throw std::runtime_error(std::string(__FILE__)+" line "+std::to_string(__LINE__));

--- a/include/Comm/Comm_Trans/Comm_Trans.h
+++ b/include/Comm/Comm_Trans/Comm_Trans.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "../Comm_Tools.h"
+#include "../global/Cereal_Func.h"
 #include "../global/Global_Func.h"
 #include <mpi.h>
 #include <functional>

--- a/include/Comm/Comm_Trans/Comm_Trans.hpp
+++ b/include/Comm/Comm_Trans/Comm_Trans.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "Comm_Trans.h"
-#include "../global/Cereal_Func.h"
 
 #include <vector>
 #include <string>

--- a/include/Comm/example/Communicate_Map-2.h
+++ b/include/Comm/example/Communicate_Map-2.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <tuple>
 #include <set>

--- a/include/Comm/example/Communicate_Set.h
+++ b/include/Comm/example/Communicate_Set.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <functional>
 #include <set>
 
 namespace Comm

--- a/include/Comm/example/Communicate_Vector.h
+++ b/include/Comm/example/Communicate_Vector.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <functional>
 #include <vector>
 
 namespace Comm


### PR DESCRIPTION
This PR adds a proper installable CMake package for LibComm, including the `LibComm::LibComm` interface target, public-header installation, exported targets, package configuration/version files, and dependency propagation.

The main motivation is downstream consumption by ABACUS. Currently, ABACUS has to install LibComm itself and maintain a custom `FindLibComm.cmake`, taking over package-management and discovery responsibilities that should belong to the upstream project. With this change, ABACUS and other consumers can simply use:

```cmake
find_package(LibComm CONFIG REQUIRED)
target_link_libraries(target PRIVATE LibComm::LibComm)
```

This removes duplicated downstream logic and reduces the maintenance burden for both LibComm and its consumers.

Note: In this CMake logic, `cereal` is required to be built with CMake; it's not supported to directly detecting non-installed header files.